### PR TITLE
Fix missing tabs in Hoppers, Droppers, and Dispensers. fixes #2.

### DIFF
--- a/src/main/java/com/kqp/inventorytabs/mixin/client/VanillaScreenTabAdder.java
+++ b/src/main/java/com/kqp/inventorytabs/mixin/client/VanillaScreenTabAdder.java
@@ -185,7 +185,9 @@ public class VanillaScreenTabAdder implements TabRenderingHints {
                 || screen instanceof CartographyTableScreen
                 || screen instanceof LoomScreen
                 || screen instanceof StonecutterScreen
-                || screen instanceof GrindstoneScreen;
+                || screen instanceof GrindstoneScreen
+                || screen instanceof HopperScreen
+                || screen instanceof Generic3x3ContainerScreen;
     }
 
     private boolean screenDoesDumbBlock() {


### PR DESCRIPTION
These blocks *seem* to be well-behaved when testing, at least in normal circumstances. Marking them as supported is all it took.