### PR TITLE
update to 1.16.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,11 @@ archives_base_name = inventorytabs
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.16.3
-yarn_mappings=1.16.3+build.38
-loader_version=0.10.1+build.209
+minecraft_version=1.16.4
+yarn_mappings=1.16.4+build.7
+loader_version=0.10.8
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.24.0+build.411-1.16
+fabric_version=0.26.3+1.16
 autoconfig_version=3044151

--- a/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
@@ -14,7 +14,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.network.packet.c2s.play.GuiCloseC2SPacket;
+import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket;
 import net.minecraft.sound.SoundEvents;
 import org.lwjgl.glfw.GLFW;
 
@@ -176,7 +176,7 @@ public class TabManager {
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player.currentScreenHandler != null) {
             client.getNetworkHandler()
-                .sendPacket(new GuiCloseC2SPacket(client.player.currentScreenHandler.syncId));
+                .sendPacket(new CloseHandledScreenC2SPacket(client.player.currentScreenHandler.syncId));
         }
 
         // Open new tab

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",
-    "minecraft": "1.16.3"
+    "minecraft": "1.16.4"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
Simply updated the mod to work with 1.16.4. The only notable change apart from updating the dependencies is that the `GuiCloseC2SPacket` was renamed to `CloseHandledScreenC2SPacket`.

PS: I made this PR to 1.16.3 branch because I can't make it to a new 1.16.4 branch. I guess it would probably be better to have a master branch always for the latest version, at least for contributing.